### PR TITLE
global.iniにこのプラグインの設定が含まれていない時に強制終了する問題を修正

### DIFF
--- a/src/update-checker/update-checker.cpp
+++ b/src/update-checker/update-checker.cpp
@@ -14,10 +14,11 @@ static bool getIsSkipping(config_t *config, const char *pluginName,
 			  const char *pluginVersion)
 {
 	bool skip = config_get_bool(config, pluginName, "check_update_skip");
-	std::string skipVersion = config_get_string(
+	const char *skipVersion = config_get_string(
 		config, pluginName, "check_update_skip_version");
 	if (skip) {
-		if (skipVersion == pluginVersion) {
+		if (skipVersion != nullptr &&
+		    std::strcmp(skipVersion, pluginVersion) == 0) {
 			return true;
 		} else {
 			config_set_bool(config, pluginName, "check_update_skip",


### PR DESCRIPTION
[message.txt](https://github.com/umireon/obs-pokemon-sv-screen-builder/files/12108563/message.txt)
